### PR TITLE
fix reconnecting

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -36,6 +36,9 @@ function setupNewDevice(device) {
             }
         });
     }
+    else {
+	client = clients[device.id];
+    }
 
     client.publish(getTopic(device, 'connected'), '2', STATUS_OPTS);
 


### PR DESCRIPTION
once a tv disconnects the mqtt client won't be reused and no mqtt client will be initiatet. fixed by reusing the existing mqtt client if it exists